### PR TITLE
fix(api): Change worker role names according to DB spec

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,7 +11,7 @@ POST /workers/signup
 | :---: |:---:| --- |
 | username | String | Worker username |
 | password | String | Worker password |
-| role | String | Worker role: <br> * *assistant* <br> * *books* <br> * *meals* <br> * *shop* <br> * *manager* |
+| role | String | Worker role: <br> * *assistant* <br> * *book* <br> * *food* <br> * *kiosk* <br> * *admin* |
 
 **Response**
 


### PR DESCRIPTION
- Now, role names are the same in API spec and DB spec. This change save us from creating a new handler to solve that situation.